### PR TITLE
BugFix: Setting extern due to change in GCC10 default to -fno-common.

### DIFF
--- a/CRT.h
+++ b/CRT.h
@@ -146,7 +146,7 @@ extern const char **CRT_treeStr;
 
 extern int CRT_delay;
 
-int* CRT_colors;
+extern int* CRT_colors;
 
 extern int CRT_colorSchemes[LAST_COLORSCHEME][LAST_COLORELEMENT];
 
@@ -156,13 +156,13 @@ extern int CRT_scrollHAmount;
 
 extern int CRT_scrollWheelVAmount;
 
-char* CRT_termType;
+extern char* CRT_termType;
 
 // TODO move color scheme to Settings, perhaps?
 
 extern int CRT_colorScheme;
 
-void *backtraceArray[128];
+extern void *backtraceArray[128];
 
 #if HAVE_SETUID_ENABLED
 

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -144,7 +144,7 @@ typedef struct LinuxProcess_ {
 #endif
 
 
-long long btime; /* semi-global */
+extern long long btime; /* semi-global */
 
 extern ProcessFieldData Process_fields[];
 


### PR DESCRIPTION
GCC defaults changed to use -fno-common causing the compilation to fail per https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678